### PR TITLE
[FEAT#3] Swagger UI 기반 API 문서 페이지 제공

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,26 @@ make run
 | Method | Path | Description |
 |--------|------|-------------|
 | GET | `/healthz` | liveness 체크 |
+| GET | `/docs` | **Swagger UI** API 문서 (브라우저) |
+| GET | `/api/v1/openapi.yaml` | OpenAPI 3.0 스펙 원본 |
 | GET | `/api/v1/manga` | 만화 목록 |
 | GET | `/api/v1/manga/{slug}` | 만화 상세 |
 | GET | `/api/v1/manga/{slug}/chapters` | 챕터 목록 |
 | GET | `/api/v1/chapters/{id}/pages` | **체크섬 포함** 페이지 매니페스트 |
 | GET | `/api/v1/chapters/{id}/pages/{index}/image` | 이미지 바이트 (`Digest` 헤더 포함) |
+
+### API 문서 (Swagger UI)
+
+서버 기동 후 브라우저에서 `/docs` 로 접속하면 모든 엔드포인트를 탐색·시도해볼 수 있습니다.
+
+```bash
+# 서버 실행 후
+open http://localhost:18080/docs            # macOS
+xdg-open http://localhost:18080/docs        # Linux
+```
+
+- Swagger UI 자체 에셋은 swagger-ui-dist CDN 에서 로드합니다 (개발 도구이므로 외부 CDN 의존 허용).
+- OpenAPI 명세는 `internal/api/openapi.yaml` 에 정의되어 있고, 빌드 시 바이너리에 임베드되어 `/api/v1/openapi.yaml` 로 서빙됩니다.
 
 ## 무결성 검증 흐름
 

--- a/internal/api/docs.go
+++ b/internal/api/docs.go
@@ -43,14 +43,16 @@ const docsHTML = `<!DOCTYPE html>
 // serveOpenAPISpec returns the embedded OpenAPI 3.0 specification.
 func serveOpenAPISpec(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "application/yaml; charset=utf-8")
-	// 스펙은 자주 바뀌지 않으므로 짧은 양수 max-age 로 클라이언트 캐싱을 허용한다.
-	w.Header().Set("Cache-Control", "public, max-age=300")
+	// 스펙은 바이너리에 임베드되어 메모리에서 서빙되므로 캐시 없이도 비용이 거의 없다.
+	// 개발 중 spec 변경 후 서버 재기동 시 브라우저가 stale 캐시를 보지 않도록 no-cache.
+	w.Header().Set("Cache-Control", "no-cache")
 	_, _ = w.Write(openapiYAML)
 }
 
 // serveSwaggerUI returns the Swagger UI HTML entry page.
 func serveSwaggerUI(w http.ResponseWriter, _ *http.Request) {
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	w.Header().Set("Cache-Control", "public, max-age=300")
+	// HTML 도 임베드된 상수이므로 캐시 비용이 없고, UI 설정 변경 시 즉시 반영되도록 no-cache.
+	w.Header().Set("Cache-Control", "no-cache")
 	_, _ = w.Write([]byte(docsHTML))
 }

--- a/internal/api/docs.go
+++ b/internal/api/docs.go
@@ -1,0 +1,56 @@
+package api
+
+import (
+	_ "embed"
+	"net/http"
+)
+
+//go:embed openapi.yaml
+var openapiYAML []byte
+
+// docsHTML is the Swagger UI entry page. It loads swagger-ui-dist from a
+// pinned-major CDN so the binary stays free of frontend assets — Swagger UI
+// is a developer tool, not a production reader-facing page.
+//
+// docsHTML 은 Swagger UI 진입 페이지입니다. swagger-ui-dist 를 고정 메이저
+// 버전의 CDN 에서 로드하므로 바이너리에 프론트엔드 에셋이 포함되지 않습니다.
+const docsHTML = `<!DOCTYPE html>
+<html lang="en">
+<head>
+	<meta charset="UTF-8">
+	<title>Steins API Docs</title>
+	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui.css">
+	<style>body { margin: 0; }</style>
+</head>
+<body>
+	<div id="swagger-ui"></div>
+	<script src="https://cdn.jsdelivr.net/npm/swagger-ui-dist@5/swagger-ui-bundle.js" crossorigin></script>
+	<script>
+		window.addEventListener('load', function () {
+			window.ui = SwaggerUIBundle({
+				url: '/api/v1/openapi.yaml',
+				dom_id: '#swagger-ui',
+				deepLinking: true,
+				presets: [SwaggerUIBundle.presets.apis],
+				layout: 'BaseLayout',
+			});
+		});
+	</script>
+</body>
+</html>
+`
+
+// serveOpenAPISpec returns the embedded OpenAPI 3.0 specification.
+func serveOpenAPISpec(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "application/yaml; charset=utf-8")
+	// 스펙은 자주 바뀌지 않으므로 짧은 양수 max-age 로 클라이언트 캐싱을 허용한다.
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write(openapiYAML)
+}
+
+// serveSwaggerUI returns the Swagger UI HTML entry page.
+func serveSwaggerUI(w http.ResponseWriter, _ *http.Request) {
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	_, _ = w.Write([]byte(docsHTML))
+}

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1,0 +1,333 @@
+openapi: 3.0.3
+info:
+  title: Steins API
+  version: 0.1.0
+  description: |
+    Steins 만화 뷰어의 v0 공개 API.
+
+    이미지 무결성:
+    - `GET /api/v1/chapters/{id}/pages` 응답의 각 페이지에는 SHA-256 체크섬이 포함됩니다.
+      포맷은 `sha-256:<base64>` 입니다.
+    - `GET /api/v1/chapters/{id}/pages/{index}/image` 응답은 RFC 9530 형식의
+      `Digest: sha-256=<base64>` 헤더를 포함합니다.
+    - 클라이언트는 다운로드 바이트의 SHA-256 을 계산해 매니페스트의 체크섬 또는
+      `Digest` 헤더와 일치하는지 확인해야 합니다.
+servers:
+  - url: /
+    description: Same-origin (개발/로컬)
+
+tags:
+  - name: system
+    description: 헬스체크 등 시스템 엔드포인트
+  - name: manga
+    description: 만화 시리즈 카탈로그
+  - name: chapter
+    description: 챕터 메타데이터
+  - name: reader
+    description: 페이지 매니페스트와 이미지 서빙
+
+paths:
+  /healthz:
+    get:
+      tags: [system]
+      summary: Liveness check
+      description: 서버가 살아있는지 확인하는 가벼운 헬스체크.
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HealthResponse'
+
+  /api/v1/manga:
+    get:
+      tags: [manga]
+      summary: 만화 카탈로그 목록 조회
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Manga'
+                  meta:
+                    $ref: '#/components/schemas/ListMeta'
+                required: [data]
+
+  /api/v1/manga/{slug}:
+    get:
+      tags: [manga]
+      summary: 만화 상세 조회
+      parameters:
+        - $ref: '#/components/parameters/MangaSlug'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Manga'
+                required: [data]
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/manga/{slug}/chapters:
+    get:
+      tags: [chapter]
+      summary: 만화의 챕터 목록 조회
+      parameters:
+        - $ref: '#/components/parameters/MangaSlug'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    type: array
+                    items:
+                      $ref: '#/components/schemas/Chapter'
+                  meta:
+                    $ref: '#/components/schemas/ListMeta'
+                required: [data]
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/chapters/{id}/pages:
+    get:
+      tags: [reader]
+      summary: 페이지 매니페스트 (체크섬 포함) 조회
+      description: |
+        해당 챕터의 모든 페이지를 페이지별 SHA-256 체크섬과 함께 반환합니다.
+        클라이언트는 각 `pages[].url` 로 이미지 바이트를 받은 뒤, 다운로드 바이트의
+        SHA-256 을 매니페스트의 `checksum` 과 비교해 무결성을 검증할 수 있습니다.
+      parameters:
+        - $ref: '#/components/parameters/ChapterID'
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  data:
+                    $ref: '#/components/schemas/Manifest'
+                required: [data]
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+  /api/v1/chapters/{id}/pages/{index}/image:
+    get:
+      tags: [reader]
+      summary: 페이지 이미지 바이트 서빙
+      description: |
+        응답 헤더 `Digest: sha-256=<base64>` 가 본문의 SHA-256 무결성 값입니다 (RFC 9530).
+        매니페스트의 `pages[].checksum` (`sha-256:<base64>`) 과 비교해 검증할 수 있습니다.
+      parameters:
+        - $ref: '#/components/parameters/ChapterID'
+        - name: index
+          in: path
+          required: true
+          description: 1-based 페이지 인덱스
+          schema:
+            type: integer
+            minimum: 1
+      responses:
+        '200':
+          description: 이미지 바이트
+          headers:
+            Digest:
+              description: RFC 9530 형식의 SHA-256 무결성 헤더 (`sha-256=<base64>`).
+              schema:
+                type: string
+            ETag:
+              description: 본문 SHA-256 base64 값을 따옴표로 감싼 ETag.
+              schema:
+                type: string
+            Cache-Control:
+              schema:
+                type: string
+                example: public, no-cache, must-revalidate
+          content:
+            image/png:
+              schema:
+                type: string
+                format: binary
+            image/jpeg:
+              schema:
+                type: string
+                format: binary
+            image/webp:
+              schema:
+                type: string
+                format: binary
+        '400':
+          $ref: '#/components/responses/ValidationFailed'
+        '404':
+          $ref: '#/components/responses/NotFound'
+
+components:
+  parameters:
+    MangaSlug:
+      name: slug
+      in: path
+      required: true
+      description: 만화 시리즈 slug (URL-safe).
+      schema:
+        type: string
+        example: steins-sample
+    ChapterID:
+      name: id
+      in: path
+      required: true
+      description: 챕터 ID (`<manga-slug>__<number>` 형식).
+      schema:
+        type: string
+        example: steins-sample__0001
+
+  schemas:
+    HealthResponse:
+      type: object
+      properties:
+        status:
+          type: string
+          example: ok
+      required: [status]
+
+    ListMeta:
+      type: object
+      properties:
+        count:
+          type: integer
+          minimum: 0
+
+    Manga:
+      type: object
+      properties:
+        id: {type: string}
+        slug: {type: string}
+        title: {type: string}
+        alt_titles:
+          type: array
+          items: {type: string}
+        description: {type: string}
+        cover_url: {type: string}
+        authors:
+          type: array
+          items: {type: string}
+        genres:
+          type: array
+          items: {type: string}
+        status:
+          type: string
+          enum: [ongoing, completed, hiatus, cancelled]
+        language:
+          type: string
+          description: ISO 639-1 (예시 ko / en)
+        reading_dir:
+          type: string
+          enum: [ltr, rtl, vertical]
+        published_at: {type: string, format: date-time}
+        updated_at: {type: string, format: date-time}
+      required: [id, slug, title, status, language, reading_dir]
+
+    Chapter:
+      type: object
+      properties:
+        id: {type: string}
+        manga_id: {type: string}
+        manga_slug: {type: string}
+        number:
+          type: string
+          description: 챕터 번호 (소수점 표기 가능 — "0001", "12.5" 등)
+        title: {type: string}
+        language: {type: string}
+        page_count:
+          type: integer
+          minimum: 0
+        published_at: {type: string, format: date-time}
+      required: [id, manga_id, manga_slug, number, page_count]
+
+    Page:
+      type: object
+      properties:
+        index:
+          type: integer
+          minimum: 1
+        url:
+          type: string
+          description: 이미지 바이트 서빙 URL (상대 경로).
+        byte_size:
+          type: integer
+          format: int64
+        mime_type:
+          type: string
+          enum: [image/png, image/jpeg, image/webp]
+        checksum:
+          type: string
+          description: |
+            무결성 검증용 본문 해시. 형식 `sha-256:<base64>` (base64 표준 인코딩).
+          example: 'sha-256:GqMCyFFpV0z921xLTFEd6gN+WN9cW/12LFIBbfnKNP4='
+      required: [index, url, byte_size, mime_type, checksum]
+
+    Manifest:
+      type: object
+      properties:
+        chapter_id: {type: string}
+        manga_id: {type: string}
+        manga_slug: {type: string}
+        number: {type: string}
+        reading_dir:
+          type: string
+          enum: [ltr, rtl, vertical]
+        page_count:
+          type: integer
+          minimum: 0
+        pages:
+          type: array
+          items:
+            $ref: '#/components/schemas/Page'
+      required: [chapter_id, manga_id, manga_slug, number, reading_dir, page_count, pages]
+
+    Error:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            code:
+              type: string
+              description: 머신-판독 에러 코드 (예 `MANGA_NOT_FOUND`, `VAL_001`).
+            message:
+              type: string
+            details:
+              type: object
+              additionalProperties: true
+          required: [code, message]
+      required: [error]
+
+  responses:
+    NotFound:
+      description: 리소스 없음
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'
+    ValidationFailed:
+      description: 입력 검증 실패
+      content:
+        application/json:
+          schema:
+            $ref: '#/components/schemas/Error'

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -29,7 +29,11 @@ func NewRouter(cfg Config, log *logger.Logger, h *handler.Handlers) http.Handler
 
 	r.Get("/healthz", h.Health)
 
+	// Developer docs — Swagger UI 진입 페이지와 OpenAPI 스펙 원본.
+	r.Get("/docs", serveSwaggerUI)
+
 	r.Route("/api/v1", func(r chi.Router) {
+		r.Get("/openapi.yaml", serveOpenAPISpec)
 		r.Get("/manga", h.ListManga)
 		r.Get("/manga/{slug}", h.GetManga)
 		r.Get("/manga/{slug}/chapters", h.ListChapters)

--- a/test/internal/api_handler/handler_test.go
+++ b/test/internal/api_handler/handler_test.go
@@ -98,6 +98,40 @@ func TestServePageImage_BadIndex_Returns400(t *testing.T) {
 	assert.Equal(t, http.StatusBadRequest, resp.StatusCode)
 }
 
+func TestServeOpenAPISpec_ReturnsYAML(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/api/v1/openapi.yaml")
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "application/yaml")
+	// Sanity: a real OpenAPI 3.x doc starts with `openapi: 3.`
+	assert.Contains(t, string(body), "openapi: 3.")
+	assert.Contains(t, string(body), "Steins API")
+}
+
+func TestServeSwaggerUI_ReturnsHTML(t *testing.T) {
+	srv := newTestServer(t)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/docs")
+	require.NoError(t, err)
+	body, err := io.ReadAll(resp.Body)
+	_ = resp.Body.Close()
+	require.NoError(t, err)
+
+	assert.Equal(t, http.StatusOK, resp.StatusCode)
+	assert.Contains(t, resp.Header.Get("Content-Type"), "text/html")
+	assert.Contains(t, string(body), "swagger-ui")
+	// The page must point Swagger UI at our spec endpoint, otherwise it loads nothing.
+	assert.Contains(t, string(body), "/api/v1/openapi.yaml")
+}
+
 // --- helpers ---
 
 type testManifest struct {


### PR DESCRIPTION
## 연관 이슈
- Closes #3

<br>

## 구현 내용
- \`internal/api/openapi.yaml\` — OpenAPI 3.0 명세 파일 신규 작성
  - v0 엔드포인트 6종 정의 (\`/healthz\`, \`/api/v1/manga\` 목록·상세·챕터목록, \`/chapters/{id}/pages\` 매니페스트, 이미지 서빙)
  - 공통 스키마 — \`Manga\`, \`Chapter\`, \`Page\`, \`Manifest\`, \`HealthResponse\`, \`ListMeta\`, \`Error\`
  - 무결성 흐름(매니페스트 \`checksum\` + RFC 9530 \`Digest\` 헤더) 문서화
- \`internal/api/docs.go\` — \`embed.FS\` 로 \`openapi.yaml\` 을 바이너리에 포함
  - \`serveOpenAPISpec\` (\`GET /api/v1/openapi.yaml\`, \`Content-Type: application/yaml\`)
  - \`serveSwaggerUI\` (\`GET /docs\`, \`Content-Type: text/html\`) — swagger-ui-dist CDN 로드
- \`internal/api/server.go\` — chi 라우터에 \`/docs\` 와 \`/api/v1/openapi.yaml\` 라우트 추가
- 핸들러 테스트 추가 — 두 엔드포인트의 Content-Type / 본문 sanity check
- README 업데이트 — 엔드포인트 표에 \`/docs\` · \`/api/v1/openapi.yaml\` 추가, \"API 문서 (Swagger UI)\" 섹션 신설

### 커밋 분리
1. \`c26b667\` [FEAT] OpenAPI 3.0 명세 파일 작성
2. \`380936e\` [FEAT] Swagger UI 진입 페이지 및 OpenAPI 스펙 서빙 핸들러 추가
3. \`8c7ef25\` [DOCS] README 에 Swagger UI 접근 경로 및 활용 안내 추가

<br>

## CI / 머지 게이트 점검

> [CI 운영 규약](docs/ci/conventions.md) 및 [Required Status Checks 단일 소스](docs/ci/status-checks.md)에 따라 작성합니다.

### 변경 영향 범위
- 영향 패키지/모듈: \`internal/api\` (라우터, 신규 핸들러, 임베드 스펙), \`test/internal/api_handler\`, \`README.md\`
- 위험도(택1): \`Low\` (신규 GET 라우트 2개 추가 + 임베드 자산. 기존 동작 변경 없음)

### Required Status Checks
- 통과 확인 대상 (PR Checks 탭에서 확인):
  - [ ] \`Commit Lint\`
  - [ ] \`PR Title Lint\`
  - [ ] \`Linked Issue Check\`
  - [ ] \`Format Check\`
  - [ ] \`Build\`
  - [ ] \`Test\`
  - [ ] \`Lint\`

### 롤백 계획
- 신규 추가만 있으므로 PR revert 한 번으로 롤백 가능. 임베드된 yaml 파일이 함께 제거되어 사이드 이펙트 없음.

<br>

## TODO
-

<br>

## 논의 사항
- swagger-ui 에셋을 CDN 에서 로드 (현재). 향후 \"오프라인/에어갭 환경\" 요구가 생기면 swagger-ui-dist 를 \`web/static\` 으로 임베드해 self-host 로 전환 예정.
- 현재 OpenAPI 명세는 hand-written. 향후 핸들러가 늘어나 SoT 와 코드의 동기화 비용이 커지면 \`swaggo/swag\` 같은 annotation-based 생성기 도입을 재검토.
- spec endpoint 경로를 \`/api/v1/openapi.yaml\` 로 둔 이유: 같은 origin 의 같은 prefix 를 따라가야 CORS / 캐시 정책이 단순해지고 React 프론트가 \`/api/v1\` prefix 를 일관되게 다룰 수 있어서.

<br>

🤖 Generated with [Claude Code](https://claude.com/claude-code)